### PR TITLE
Potential fix for code scanning alert no. 789: Missing rate limiting

### DIFF
--- a/services/user-sinhvienservice/package.json
+++ b/services/user-sinhvienservice/package.json
@@ -26,7 +26,8 @@
     "helmet": "^5.1.0",
     "jsonwebtoken": "^9.0.0",
     "morgan": "^1.10.1",
-    "mssql": "^11.0.1"
+    "mssql": "^11.0.1",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "nodemon": "^2.0.16"

--- a/services/user-sinhvienservice/src/routes/examRegistrationRoutes.js
+++ b/services/user-sinhvienservice/src/routes/examRegistrationRoutes.js
@@ -10,6 +10,14 @@ const router = express.Router();
 const examRegistrationController = require('../controllers/examRegistrationController');
 const { body } = require('express-validator');
 const authMiddleware = require('../middleware/auth');
+const rateLimit = require('express-rate-limit');
+
+// Configure rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: 'Too many requests from this IP, please try again later.'
+});
 
 // Static routes (must come before dynamic userId routes)
 /**
@@ -19,6 +27,7 @@ const authMiddleware = require('../middleware/auth');
  */
 router.get(
   '/semesters',
+  limiter, // Apply rate limiter middleware
   authMiddleware.authenticate,
   authMiddleware.authorize(),
   examRegistrationController.getActiveSemesters


### PR DESCRIPTION
Potential fix for [https://github.com/DucQuyen199/Campus-Learning/security/code-scanning/789](https://github.com/DucQuyen199/Campus-Learning/security/code-scanning/789)

To address the issue, we will add rate limiting to the `/semesters` route using the `express-rate-limit` package. This package allows us to define a maximum number of requests per time window for specific routes. The fix involves:

1. Installing and importing the `express-rate-limit` package.
2. Configuring a rate limiter with appropriate settings (e.g., maximum requests per minute).
3. Applying the rate limiter middleware to the `/semesters` route.

This fix ensures that the route is protected against abuse while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
